### PR TITLE
Decompression tweak

### DIFF
--- a/spym/io/rhksm4/_sm4.py
+++ b/spym/io/rhksm4/_sm4.py
@@ -614,7 +614,7 @@ class RHKObjectContainer:
             PRMdata = np.fromfile(self._sm4._file, dtype=np.uint32, count=self._PRM_DataSize)
         elif self._PRM_CompressionFlag == 1:
             comprPRMdata = np.fromfile(self._sm4._file, dtype=np.uint32, count=self._PRM_CompressionSize)
-            PRMdata = zlib.decompress(comprPRMdata, wbits=0, bufsize=self._PRM_DataSize)
+            PRMdata = zlib.decompressobj(wbits=0).decompress(comprPRMdata,self._PRM_DataSize)
 
         self.attrs['RHK_PRMdata'] = PRMdata.decode('CP437')
 


### PR DESCRIPTION
Loading some files may lead to "zlib.error: Error -5 while decompressing data: incomplete or truncated stream", this code fixes that by changing the decompression slightly in order to avoid running out of memory by buffering the data first.