### PR TITLE
np.float to np.float64

### DIFF
--- a/spym/io/omicronscala/_scala.py
+++ b/spym/io/omicronscala/_scala.py
@@ -245,5 +245,5 @@ class OMICRONchannel:
         xres = self.attrs['IncrementX']
         ysize = self.attrs['ImageSizeinY']
         yres = self.attrs['IncrementY']
-        self.coords = [('y', yres * np.arange(ysize, dtype=np.float)),
-                       ('x', xres * np.arange(xsize, dtype=np.float))]
+        self.coords = [('y', yres * np.arange(ysize, dtype=np.float64)),
+                       ('x', xres * np.arange(xsize, dtype=np.float64))]


### PR DESCRIPTION
Changed np.float to np.float64 in the initialization of the `OMICRONchannel` variable `coords`.
Using newer versions of `numpy` where the `np.float` alias is no longer supported resulted in the file load error: `Error: the file does not appear to be valid.`

In addition, I believe you should add a `requirements.txt` file to the package, so that one can install the requirements during installation via pip.